### PR TITLE
Rob/sg testing

### DIFF
--- a/project-1/main.jl
+++ b/project-1/main.jl
@@ -401,7 +401,7 @@ function init_steady_state(machine, avr, turbine_gov, network, pf_solution)
 
     # Check validity of initial condition
     du0 = Vector{Float64}(undef, 12) # return object for derivative calculation
-    perturbations = d = Dict{String,Int}()
+    perturbations = Dict{String,Int}()
     p = (machine, avr, turbine_gov, network, perturbations)
     synchronous_machine_dynamics!(du0, u0, p, 0)
 


### PR DESCRIPTION
This PR introduces several changes to the dynamic equation solution and initialization as detailed in the commit messages.

The commits with the most significant changes are [5e94b97](https://github.com/muhi-zatar/ECEN-5447-assignments/commit/5e94b970474771c2b36527337ab91f34132b811e) and [5df94a8](https://github.com/muhi-zatar/ECEN-5447-assignments/commit/5df94a81beb2cd7fa51be376f0bd50b28e6dcdb9).

These changes were tested using the voltage reference step simulation. The system did **not** initialize correctly. The initial derivatives were found to be:
```julia
du[1] = 0.0
du[2] = -0.20469486835471112
du[3] = 9.762345841465008e-5
du[4] = -19.91857091160138
du[5] = 0.0024617778573138684
du[6] = -3.7761881669572688
du[7] = -100.0
du[8] = 0.0
du[9] = -0.46402051523691246
du[10] = -4.0
du[11] = 0.0
du[12] = 0.0
```

Where du is`du0 = d[δ0, 1.0, Eq_p0, Ed_p0, ψq_pp0, ψd_pp0, Vr_0, Vf_0, Rf_0, Pg_0, Pm_hp0, Pm_lp0]`

The worst-offending states are Vr_0, Ed_p0, and ψd_pp0, so these are good candidates to start investigating.